### PR TITLE
Move GitHub API URL to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ PORT=
 
 # Provide your GitHub Personal access token
 GITHUB_PERSONAL_ACCESS_TOKEN=
+
+# Supply base URL
+GITHUB_API_URL=

--- a/server.js
+++ b/server.js
@@ -11,10 +11,9 @@ app.use(express.static("public")); // Serve static files from the 'public' direc
 // Web-app-fetching-pull-request-from-GitHub
 
 const PORT = process.env.PORT || 3000;
-const GITHUB_ISSUES_API_URL =
-  "https://api.github.com/repos/KBandipo/GitHub-REST-API/issues";
-const GITHUB_PR_API_URL =
-  "https://api.github.com/repos/KBandipo/GitHub-REST-API/pulls";
+const GITHUB_API_URL = process.env.GITHUB_API_URL;
+const GITHUB_ISSUES_API_URL = `${GITHUB_API_URL}/issues`;
+const GITHUB_PR_API_URL = `${GITHUB_API_URL}/pulls`;
 
 // Endpoint to get issues
 app.get("/issues", async (req, res) => {

--- a/server.js
+++ b/server.js
@@ -8,17 +8,12 @@ const app = express();
 app.use(express.json());
 app.use(express.static("public")); // Serve static files from the 'public' directory
 
-// Web-app-fetching-pull-request-from-GitHub
-
 const PORT = process.env.PORT || 3000;
-const GITHUB_API_URL = process.env.GITHUB_API_URL;
-const GITHUB_ISSUES_API_URL = `${GITHUB_API_URL}/issues`;
-const GITHUB_PR_API_URL = `${GITHUB_API_URL}/pulls`;
 
 // Endpoint to get issues
 app.get("/issues", async (req, res) => {
   try {
-    const response = await fetch(GITHUB_ISSUES_API_URL, {
+    const response = await fetch(`${process.env.GITHUB_API_URL}/issues`, {
       headers: {
         Authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
       },
@@ -37,7 +32,7 @@ app.get("/issues", async (req, res) => {
 app.post("/issues", async (req, res) => {
   const { title, body } = req.body;
   try {
-    const response = await fetch(GITHUB_ISSUES_API_URL, {
+    const response = await fetch(`${process.env.GITHUB_API_URL}/issues`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -63,7 +58,7 @@ app.post("/issues", async (req, res) => {
 // Endpoint to get pull requests
 app.get("/pull-requests", async (req, res) => {
   try {
-    const response = await fetch(GITHUB_PR_API_URL, {
+    const response = await fetch(`${process.env.GITHUB_API_URL}/pulls`, {
       headers: {
         Authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
       },


### PR DESCRIPTION
This pull request refactors the code to use an environment variable for the GitHub API base URL. These were the changes made

- Added GITHUB_API_URL to the .env.
- Updated server.js to use the base URL from the environment variable for API requests and merge with the endpoints (/issues and /pulls).
- Updated the .env.example file to reflect the new GITHUB_API_URL variable.