### PR TITLE
Customize Title and Body of Issue submitted via Collabocate GitHubSync

### DIFF
--- a/server.js
+++ b/server.js
@@ -44,7 +44,10 @@ app.post("/issues", async (req, res) => {
         "Content-Type": "application/json",
         Authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
       },
-      body: JSON.stringify({ title, body }),
+      body: JSON.stringify({ 
+        title: `[GitHubSync] ${title}`,
+        body: body + '\n\n' + '#' + '\n' + '> Submitted via **Collabocate** [[GitHubSync]](https://github.com/collabo-community/collabocate)',
+      }),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
These happen:
- `[GitHubSync]` is automatically added before the issue title submitted
- At the end of the body of the Issue description, this markdown below is added: 
#
> Submitted via **Collabocate** [[GitHubSync]](https://github.com/collabo-community/collabocate)