### PR TITLE
Fix: Set Up State Management with unstated-next for Collabocate UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   "license": "AGPL v3.0",
   "contributors": [
     "Find list of contributors in project README: https://github.com/collabo-community/collabocate?tab=readme-ov-file#contributors"
-  ]
+  ],
+  "dependencies": {
+    "unstated-next": "^1.1.0"
+  }
 }

--- a/src/components/@hooks_state/useGlobal.tsx
+++ b/src/components/@hooks_state/useGlobal.tsx
@@ -1,13 +1,16 @@
 import React, { useState } from 'react';
 import { createContainer } from 'unstated-next';
 
-function useGlobalState() {
-  const [instanceId, setInstanceId] = useState('');
+function useGlobalState(initialState = { instanceId: '' }) {
+  const [instanceId, setInstanceId] = useState(initialState.instanceId);
+
+  const updateInstanceId = (id: string) => {
+    setInstanceId(id);
+  };
 
   return {
     instanceId,
-    setInstanceId
+    updateInstanceId
   };
 }
-
 export const GlobalContainer = createContainer(useGlobalState);

--- a/src/components/@hooks_state/useGlobal.tsx
+++ b/src/components/@hooks_state/useGlobal.tsx
@@ -1,0 +1,13 @@
+import React, { useState } from 'react';
+import { createContainer } from 'unstated-next';
+
+function useGlobalState() {
+  const [instanceId, setInstanceId] = useState('');
+
+  return {
+    instanceId,
+    setInstanceId
+  };
+}
+
+export const GlobalContainer = createContainer(useGlobalState);

--- a/src/components/@section_controls/FloatingActionControls.tsx
+++ b/src/components/@section_controls/FloatingActionControls.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { Container } from '../@helpers/Container';
+import { GlobalContainer } from '../@hooks_state/useGlobal';
 
 export interface FloatingActionControlsProps extends React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {}
 
 export const FloatingActionControls: React.FunctionComponent<FloatingActionControlsProps> = (props: FloatingActionControlsProps) => {
+  const { instanceId, updateInstanceId } = GlobalContainer.useContainer();
+  console.log('FloatingActionControls instance_id:', instanceId);
   return (
     <>
       <Container bb_function="display" bb_function_class="bb-disp-inline-flex" bb_class="bb-floating-controls">

--- a/src/components/@section_modal/ModalPopup.tsx
+++ b/src/components/@section_modal/ModalPopup.tsx
@@ -1,51 +1,40 @@
 import React from 'react';
 import { Dropdown } from '../@helpers/dropdown/Dropdown';
-import { GlobalContainer } from '../@hooks_state/useGlobal';
 
 export interface ModalPopupProps extends React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {}
 
 export const ModalPopup: React.FunctionComponent<ModalPopupProps> = (props: ModalPopupProps) => {
-  const { instanceId, updateInstanceId } = GlobalContainer.useContainer();
-  console.log('ModalPopup instance_id:', instanceId);
   return (
     <>
       <div className="bb-collabocate_body">
-        <header className="bb-collabocate_header">
-          <div className="bb-content-group__collabocate_plugin bb-collabocate_header-inner">
-            <h4>Report Issue</h4>
-            {/* <div className="bb-collabocate_font-zero">
+        <header className="bb-collabocate_header"> 
+            <div className="bb-content-group__collabocate_plugin bb-collabocate_header-inner">
+                <h4>Report Issue</h4>
+                {/* <div className="bb-collabocate_font-zero">
                     <button className="bb-collabocate_close-btn">
                         <img src="../assets/close-icon.png" alt="Exit icon" />
                     </button>
                 </div> */}
-          </div>
-          <p className="bb-content-group__collabocate_plugin">Collabocate | GitHub Sync</p>
+            </div>
+            <p className="bb-content-group__collabocate_plugin">Collabocate | GitHub Sync</p>
         </header>
         <form className="bb-content-group__collabocate_plugin bb-collabocate_form" id="submitIssueForm">
           <div>
-            <label className="bb-collabocate_label" htmlFor="issueTemplates">
-              Choose Report Type
-            </label>
+            <label className="bb-collabocate_label" htmlFor="issueTemplates">Choose Report Type</label>
             <br />
             <Dropdown />
           </div>
           <div>
-            <label className="bb-collabocate_label" htmlFor="issueTitle">
-              Issue Title
-            </label>
+            <label className="bb-collabocate_label" htmlFor="issueTitle">Issue Title</label>
             <br />
             <input className="bb-content-group__collabocate_form-inner bb-collabocate_input" type="text" id="issueTitle" />
           </div>
           <div>
-            <label className="bb-collabocate_label" htmlFor="issueBody">
-              Issue Body
-            </label>
+            <label className="bb-collabocate_label" htmlFor="issueBody">Issue Body</label>
             <br />
             <textarea className="bb-content-group__collabocate_form-inner bb-collabocate_input bb-collabocate_textarea" id="issueBody"></textarea>
           </div>
-          <button className="bb-content-group__collabocate_form-inner bb-collabocate_submit-form-button" id="submitIssueButton">
-            Submit Issue Ticket
-          </button>
+          <button className="bb-content-group__collabocate_form-inner bb-collabocate_submit-form-button" id="submitIssueButton">Submit Issue Ticket</button>
           <div id="displayToastrMessage"></div>
         </form>
       </div>

--- a/src/components/@section_modal/ModalPopup.tsx
+++ b/src/components/@section_modal/ModalPopup.tsx
@@ -1,40 +1,51 @@
 import React from 'react';
 import { Dropdown } from '../@helpers/dropdown/Dropdown';
+import { GlobalContainer } from '../@hooks_state/useGlobal';
 
 export interface ModalPopupProps extends React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {}
 
 export const ModalPopup: React.FunctionComponent<ModalPopupProps> = (props: ModalPopupProps) => {
+  const { instanceId, updateInstanceId } = GlobalContainer.useContainer();
+  console.log('ModalPopup instance_id:', instanceId);
   return (
     <>
       <div className="bb-collabocate_body">
-        <header className="bb-collabocate_header"> 
-            <div className="bb-content-group__collabocate_plugin bb-collabocate_header-inner">
-                <h4>Report Issue</h4>
-                {/* <div className="bb-collabocate_font-zero">
+        <header className="bb-collabocate_header">
+          <div className="bb-content-group__collabocate_plugin bb-collabocate_header-inner">
+            <h4>Report Issue</h4>
+            {/* <div className="bb-collabocate_font-zero">
                     <button className="bb-collabocate_close-btn">
                         <img src="../assets/close-icon.png" alt="Exit icon" />
                     </button>
                 </div> */}
-            </div>
-            <p className="bb-content-group__collabocate_plugin">Collabocate | GitHub Sync</p>
+          </div>
+          <p className="bb-content-group__collabocate_plugin">Collabocate | GitHub Sync</p>
         </header>
         <form className="bb-content-group__collabocate_plugin bb-collabocate_form" id="submitIssueForm">
           <div>
-            <label className="bb-collabocate_label" htmlFor="issueTemplates">Choose Report Type</label>
+            <label className="bb-collabocate_label" htmlFor="issueTemplates">
+              Choose Report Type
+            </label>
             <br />
             <Dropdown />
           </div>
           <div>
-            <label className="bb-collabocate_label" htmlFor="issueTitle">Issue Title</label>
+            <label className="bb-collabocate_label" htmlFor="issueTitle">
+              Issue Title
+            </label>
             <br />
             <input className="bb-content-group__collabocate_form-inner bb-collabocate_input" type="text" id="issueTitle" />
           </div>
           <div>
-            <label className="bb-collabocate_label" htmlFor="issueBody">Issue Body</label>
+            <label className="bb-collabocate_label" htmlFor="issueBody">
+              Issue Body
+            </label>
             <br />
             <textarea className="bb-content-group__collabocate_form-inner bb-collabocate_input bb-collabocate_textarea" id="issueBody"></textarea>
           </div>
-          <button className="bb-content-group__collabocate_form-inner bb-collabocate_submit-form-button" id="submitIssueButton">Submit Issue Ticket</button>
+          <button className="bb-content-group__collabocate_form-inner bb-collabocate_submit-form-button" id="submitIssueButton">
+            Submit Issue Ticket
+          </button>
           <div id="displayToastrMessage"></div>
         </form>
       </div>

--- a/src/components/Collabocate.tsx
+++ b/src/components/Collabocate.tsx
@@ -5,6 +5,7 @@ import { FloatingActionControls } from './@section_controls/FloatingActionContro
 import { ModalPopup } from './@section_modal/ModalPopup';
 import { Container } from './@helpers/Container';
 import { Debugger } from './@helpers/Debugger';
+import { GlobalContainer } from './@hooks_state/useGlobal';
 
 export interface CollabocateProps extends React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
   instance_id: string;
@@ -15,23 +16,22 @@ export const Collabocate: React.FunctionComponent<CollabocateProps> = ({ instanc
   if (!instance_id.length) {
     return (
       <>
-        <Debugger 
+        <Debugger
           message="DEBUGGER: Supply instance_id prop to the Collabocate Component, for plugin to show up on the UI. See docs..."
           bb_function="position"
-          bb_function_class="bb-pos-fixed bb-pos-r30-b20" 
-          bb_class="bb-collabocate_container" 
-        />;
+          bb_function_class="bb-pos-fixed bb-pos-r30-b20"
+          bb_class="bb-collabocate_container"
+        />
+        ;
       </>
     );
   }
   return (
-    <Container 
-      bb_function="position" 
-      bb_function_class="bb-pos-fixed bb-pos-r30-b20" 
-      bb_class='bb-collabocate_container'
-    >
-      <ModalPopup />
-      <FloatingActionControls />
-    </Container>
+    <GlobalContainer.Provider initialState={{ instanceId: instance_id }}>
+      <Container bb_function="position" bb_function_class="bb-pos-fixed bb-pos-r30-b20" bb_class="bb-collabocate_container">
+        <ModalPopup />
+        <FloatingActionControls />
+      </Container>
+    </GlobalContainer.Provider>
   );
 };

--- a/src/components/Collabocate.tsx
+++ b/src/components/Collabocate.tsx
@@ -16,19 +16,23 @@ export const Collabocate: React.FunctionComponent<CollabocateProps> = ({ instanc
   if (!instance_id.length) {
     return (
       <>
-        <Debugger
+        <Debugger 
           message="DEBUGGER: Supply instance_id prop to the Collabocate Component, for plugin to show up on the UI. See docs..."
           bb_function="position"
           bb_function_class="bb-pos-fixed bb-pos-r30-b20"
           bb_class="bb-collabocate_container"
-        />
-        ;
+        />;
       </>
     );
   }
   return (
     <GlobalContainer.Provider initialState={{ instanceId: instance_id }}>
-    <Container bb_function="position" bb_function_class="bb-pos-fixed bb-pos-r30-b20" bb_class="bb-collabocate_container">
+    <Container 
+      bb_function="position" 
+      bb_function_class="bb-pos-fixed 
+      bb-pos-r30-b20" 
+      bb_class="bb-collabocate_container"
+    >
       <ModalPopup />
       <FloatingActionControls />
     </Container>

--- a/src/components/Collabocate.tsx
+++ b/src/components/Collabocate.tsx
@@ -19,8 +19,8 @@ export const Collabocate: React.FunctionComponent<CollabocateProps> = ({ instanc
         <Debugger 
           message="DEBUGGER: Supply instance_id prop to the Collabocate Component, for plugin to show up on the UI. See docs..."
           bb_function="position"
-          bb_function_class="bb-pos-fixed bb-pos-r30-b20"
-          bb_class="bb-collabocate_container"
+          bb_function_class="bb-pos-fixed bb-pos-r30-b20" 
+          bb_class="bb-collabocate_container" 
         />;
       </>
     );
@@ -29,9 +29,8 @@ export const Collabocate: React.FunctionComponent<CollabocateProps> = ({ instanc
     <GlobalContainer.Provider initialState={{ instanceId: instance_id }}>
     <Container 
       bb_function="position" 
-      bb_function_class="bb-pos-fixed 
-      bb-pos-r30-b20" 
-      bb_class="bb-collabocate_container"
+      bb_function_class="bb-pos-fixed bb-pos-r30-b20" 
+      bb_class='bb-collabocate_container'
     >
       <ModalPopup />
       <FloatingActionControls />

--- a/src/components/Collabocate.tsx
+++ b/src/components/Collabocate.tsx
@@ -28,10 +28,10 @@ export const Collabocate: React.FunctionComponent<CollabocateProps> = ({ instanc
   }
   return (
     <GlobalContainer.Provider initialState={{ instanceId: instance_id }}>
-      <Container bb_function="position" bb_function_class="bb-pos-fixed bb-pos-r30-b20" bb_class="bb-collabocate_container">
-        <ModalPopup />
-        <FloatingActionControls />
-      </Container>
+    <Container bb_function="position" bb_function_class="bb-pos-fixed bb-pos-r30-b20" bb_class="bb-collabocate_container">
+      <ModalPopup />
+      <FloatingActionControls />
+    </Container>
     </GlobalContainer.Provider>
   );
 };


### PR DESCRIPTION
#### This pull request makes the following changes

* Fixes collabo-community/issue-tickets-ready-for-fixing#76

#

#### General checklist

- [x] My pull request adheres to the [Collabo Community pull request guidelines](https://docs.collabocommunity.com/pull-request-guidelines).
- [x] I have read and understood the **Pull request guideline extension** section found at the bottom of this pull request description/body.
- [x] I have replaced the dummy text under the subheading **Testing checklist** below with the testing checklist from the issue ticket I'm working on.

#

#### Testing checklist

- [x] A folder named `@hooks_state` is at the root of the `src/components` folder
- [x] There's an `useGlobal.tsx` file is inside `@hooks_state` folder
- [x] The useGlobal.tsx file manages the global state that controls getting and setting `instance_id`
- [x] The `<GlobalContainer.Provider>` is used as needed in `Collabocate.tsx` file, to help provide the global state to children components
- [x] The `<ModalPopup />` and `<FloatingActionControls />` components can access the `instance_id` using `GlobalContainer.useContainer()`, without having to pass the id as props from the parent
- [x] A `console.log` or `alert` has been added inside `<ModalPopup />` and `<FloatingActionControls />` to confirm that we are able to access the `instance_id`
- [x] I certify that I ran my checklist

#

#### Pull request guideline extension

> [!NOTE]  
> Do not remove this note or section. This talks about extra things to take note of, in addition to the directions given in the Collabo Community pull request guidelines.

We appreciate the time taken to help tackle issue tickets within the Collabo Community. Please go ahead to submit your pull request even if it is not yet completed, and push to the pull request actively. This will allow us to know that you have not abandoned the issue ticket. However, you should only alert reviewers about your pull request as explained below, to avoid flooding their GitHub notifications unnecessarily.

"Ready for review" implies that things are working as expected, according to how it is specified in the issue ticket you are working on. Ensure that you test the code that you are working on, that it works as expected. Don't just request for review when your pull request is not yet done and working.

The only time you should be making people review something incomplete is: if you want to show them what's not working, so that they can send help or guidance. If this is the case, be explicit about this in our Discord community or in the comment of your pull request (after you have submitted the pull request).
